### PR TITLE
[FR-155] Mark messages that failed to send as red

### DIFF
--- a/src/Content/index.tsx
+++ b/src/Content/index.tsx
@@ -209,7 +209,10 @@ function Content(props: ContentProps) {
           referencedMessage={props.message}
           showTooltip={props.isReplyContent ?? false}
         >
-          <Styles.ContentContainer isReplyContent={props.isReplyContent}>
+          <Styles.ContentContainer
+            isReplyContent={props.isReplyContent}
+            didFailToSend={props.message.failedToSend}
+          >
             {props.message.content.length > 0 ? (
               <>
                 {props.message.webhook_id !== undefined ? (

--- a/src/Content/style.ts
+++ b/src/Content/style.ts
@@ -62,6 +62,11 @@ export const ContentContainer = styled.withConfig({
   lineHeight: "1.375rem",
 
   variants: {
+    didFailToSend: {
+      true: {
+        color: theme.colors.danger,
+      },
+    },
     isReplyContent: {
       true: {
         overflow: "hidden",

--- a/src/stories/Normal.stories.tsx
+++ b/src/stories/Normal.stories.tsx
@@ -152,6 +152,58 @@ ExtendedMarkdown.args = {
   ],
 };
 
+export const FailedToSend: StoryFn<typeof MessageGroup> = Template.bind({});
+FailedToSend.args = {
+  messages: [
+    {
+      id: "1101622366137749574",
+      type: 0,
+      content:
+        'Small update on expanded markdown <:Kermit:865566651017068554>\nWe had to roll it back yesterday to patch some issues. We will most likely be bringing it back ~~sometime next week.~~ soon <:KermitTPose:814341617234083871> \n\nHave a good, markdown-less weekend! <:KermitCloutGlasses:874106679321571428>\n\nAnimal fact of the week: a group of rhino is called a "crash" 🦏',
+      channel_id: "697138785317814292",
+      author: {
+        id: "933123872641921044",
+        username: "therealjethro",
+        global_name: "Jeff",
+        avatar: "e4d8c186d8900eed2ace6aed5cefe1c0",
+        discriminator: "0",
+        public_flags: 4604871,
+      },
+      failedToSend: true,
+      attachments: [],
+      embeds: [],
+      mentions: [],
+      mention_roles: [],
+      pinned: false,
+      mention_everyone: false,
+      tts: false,
+      timestamp: "2023-04-28T21:33:59.241000+00:00",
+      edited_timestamp: "2023-05-04T16:50:42.356000+00:00",
+      flags: 1,
+      components: [],
+      reactions: [
+        {
+          emoji: {
+            id: "1100159330264813638",
+            name: "frog_nae_nae",
+            animated: true,
+          },
+          count: 241,
+          me: false,
+        },
+        {
+          emoji: {
+            id: null,
+            name: "🦏",
+          },
+          count: 272,
+          me: true,
+        },
+      ],
+    },
+  ],
+};
+
 export const Reactions: StoryFn<typeof MessageGroup> = Template.bind({});
 Reactions.args = {
   messages: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,4 +2,5 @@ import type { APIMessage } from "discord-api-types/v10";
 
 export interface ChatMessage extends APIMessage {
   optimistic?: boolean;
+  failedToSend?: boolean;
 }


### PR DESCRIPTION
![image](https://github.com/widgetbot-io/message-renderer/assets/24935987/58c8be77-f6d0-48f6-948a-76492c899fb5)
